### PR TITLE
Use atomic file writes for writing files

### DIFF
--- a/output/file.go
+++ b/output/file.go
@@ -1,7 +1,7 @@
 package output
 
 import (
-	"io/ioutil"
+	"github.com/youtube/vitess/go/ioutil2"
 	"os"
 )
 
@@ -20,5 +20,5 @@ func NewFileWriter(targetFile string) *FileWriter {
 }
 
 func (w *FileWriter) write(output string) error {
-	return ioutil.WriteFile(w.targetFile, []byte(output), w.fileMode)
+	return ioutil2.WriteFileAtomic(w.targetFile, []byte(output), w.fileMode)
 }


### PR DESCRIPTION
Using non-atomic file writes could result in an empty file if i.e. the disk is full.

We avoid this by first writing a temporary file and then renaming/moving it.

Fixes #4.