### PR TITLE
Provide version number on Travis build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+fetch-ssh-keys

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ script:
   # - go test -v -covermode=count -coverprofile=coverage.out ./...
   # - $HOME/gopath/bin/goveralls -coverprofile=coverage.out -service travis-ci -repotoken $COVERALLS_TOKEN
 after_success:
-  - gox -output "dist/{{.OS}}_{{.Arch}}_{{.Dir}}"
+  - gox -ldflags "-X main.VersionString=$TRAVIS_TAG" -output "dist/{{.OS}}_{{.Arch}}_{{.Dir}}"
   - ghr --username ernoaapa --token $GITHUB_TOKEN --replace --prerelease --debug pre-release dist/
 deploy:
   provider: script

--- a/main.go
+++ b/main.go
@@ -10,6 +10,10 @@ import (
 	"github.com/urfave/cli"
 )
 
+var (
+	VersionString string
+)
+
 // StatsdConfig for statsd client
 type StatsdConfig struct {
 	Host       string `default:"localhost"`
@@ -29,6 +33,7 @@ func main() {
 			Value: "ssh",
 		},
 	}
+	app.Version = VersionString
 	app.Commands = []cli.Command{
 		{
 			Name:  "github",


### PR DESCRIPTION
I noticed the output of `fetch-ssh-keys --help` listed the version `0.0.0`.

This pull request makes Travis CI add the version number during builds.

When building without specifying version string via `-X main.VersionString=$TRAVIS_TAG` the version string will be empty and that just makes `github.com/urfave/cli` leave out the version from the output.

I setup a test build on Travis CI the results can be seen here:
- https://travis-ci.org/arnested/fetch-ssh-keys/builds/197286926
- https://github.com/arnested/fetch-ssh-keys/releases/tag/v1.0.2-alpha6