### PR TITLE
Make file permission a command line option

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Tool can be used for example to automatically update `.ssh/authorized_keys` file
 | Parameter      | Required          | Description                                                                                               |
 |----------------|-------------------|-----------------------------------------------------------------------------------------------------------|
 | --format       | No (default ssh)  | Output format. Only ssh authorized_keys format supported for now                                          |
+| --file-mode    | No (default 0600) | File permissions when writing to a file                                                                   |
 
 #### GitHub
 | Parameter      | Required | Description                                                                                               |

--- a/format/ssh_test.go
+++ b/format/ssh_test.go
@@ -12,7 +12,7 @@ func TestSsh(t *testing.T) {
 	log.SetLevel(log.DebugLevel)
 
 	keys := map[string][]string{
-		"ernoaapa": []string{
+		"ernoaapa": {
 			"ssh-rsa AAAAB3NzsshPublicKeyBlah",
 		},
 	}

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/urfave/cli"
 )
 
+// Version string to be set at compile time via command line (-ldflags "-X main.VersionString=1.2.3")
 var (
 	VersionString string
 )

--- a/main.go
+++ b/main.go
@@ -33,6 +33,11 @@ func main() {
 			Usage: "Output format. One of: ssh",
 			Value: "ssh",
 		},
+		cli.StringFlag{
+			Name:  "file-mode",
+			Usage: "File permissions for file",
+			Value: "0600",
+		},
 	}
 	app.Version = VersionString
 	app.Commands = []cli.Command{
@@ -73,7 +78,7 @@ func main() {
 					log.Fatalln("Failed to fetch keys", err)
 				}
 
-				return output.Write(c.GlobalString("format"), c.Args().Get(0), keys)
+				return output.Write(c.GlobalString("format"), c.Args().Get(0), os.FileMode(c.GlobalInt("file-mode")), keys)
 			},
 		},
 	}

--- a/output/file.go
+++ b/output/file.go
@@ -12,10 +12,10 @@ type FileWriter struct {
 }
 
 // NewFileWriter creates new FileWriter what writes to targetFile
-func NewFileWriter(targetFile string) *FileWriter {
+func NewFileWriter(targetFile string, perm os.FileMode) *FileWriter {
 	return &FileWriter{
 		targetFile: targetFile,
-		fileMode:   0600,
+		fileMode:   perm,
 	}
 }
 

--- a/output/file_test.go
+++ b/output/file_test.go
@@ -2,6 +2,7 @@ package output
 
 import (
 	"io/ioutil"
+	"os"
 	"testing"
 
 	log "github.com/Sirupsen/logrus"
@@ -15,7 +16,7 @@ func TestFile(t *testing.T) {
 	file, createErr := ioutil.TempFile("", "example")
 	assert.NoError(t, createErr, "Unable to create temp file")
 
-	writer := NewFileWriter(file.Name())
+	writer := NewFileWriter(file.Name(), 0640)
 
 	writer.write("foobar")
 	writer.write("foobar-second-time")
@@ -23,5 +24,7 @@ func TestFile(t *testing.T) {
 	fileBytes, readErr := ioutil.ReadFile(file.Name())
 	assert.NoError(t, readErr, "Unable to read temp file")
 
+	info, _ := os.Stat(file.Name())
+	assert.Equal(t, 0640, int(info.Mode().Perm()), "File permission wasn't set as expected")
 	assert.Equal(t, "foobar-second-time", string(fileBytes), "FileWriter didnt wrote expected output to file")
 }

--- a/output/writer.go
+++ b/output/writer.go
@@ -1,6 +1,9 @@
 package output
 
-import "github.com/ernoaapa/fetch-ssh-keys/format"
+import (
+	"github.com/ernoaapa/fetch-ssh-keys/format"
+	"os"
+)
 
 // Writer is interface for all output writers
 type Writer interface {
@@ -8,16 +11,16 @@ type Writer interface {
 }
 
 // Write writes keys to given outputName in given formatName
-func Write(formatName, target string, keysByUsername map[string][]string) error {
-	writer := getWriter(target)
+func Write(formatName, target string, perm os.FileMode, keysByUsername map[string][]string) error {
+	writer := getWriter(target, perm)
 	return writer.write(format.Build(formatName, keysByUsername))
 }
 
-func getWriter(target string) Writer {
+func getWriter(target string, perm os.FileMode) Writer {
 	switch target {
 	case "":
 		return &StdoutWriter{}
 	default:
-		return NewFileWriter(target)
+		return NewFileWriter(target, perm)
 	}
 }


### PR DESCRIPTION
I would like to be able to configure the file permissions of the file written (`0600` is only a strict requirement for authorized key files in a users home directory).

This adds a `--file-mode` option for specifying the permissions. Defaulting to `0600`.

My use case is writing the file outside the users home directory with the user having permission to read the file but not change. This way I can prohibit a user manipulating the file in between cron runs updating it.

I also fixed two minor code style issues bringing the score at [Go Report Card](https://goreportcard.com/report/github.com/ernoaapa/fetch-ssh-keys) up to a 100%.