### PR TITLE
Add support for using team option multiple times

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.7
+  - 1.9
 
 before_install:
   - go get github.com/mitchellh/gox

--- a/main.go
+++ b/main.go
@@ -51,9 +51,9 @@ func main() {
 					Name:  "public-only",
 					Usage: "Return only public members of organization",
 				},
-				cli.StringFlag{
+				cli.StringSliceFlag{
 					Name:  "team",
-					Usage: "Return only members of one team",
+					Usage: "Return only members of `TEAM` (this option can be used multiple times for multiple teams)",
 				},
 			},
 			Action: func(c *cli.Context) error {
@@ -63,7 +63,7 @@ func main() {
 
 				keys, err := fetch.GitHubKeys(c.String("organization"), fetch.GithubFetchParams{
 					Token:             c.String("token"),
-					TeamName:          c.String("team"),
+					TeamNames:         c.StringSlice("team"),
 					PublicMembersOnly: c.Bool("public-only"),
 				})
 				if err != nil {


### PR DESCRIPTION
This adds support for fetching keys from multiple teams by using the `--team` option multiple times.

The `github.com/google/go-github/github` now uses the `context` package so I had to add changes for that as well. The context package is still a mystery to me so I'm not sure I'm using it the right way.