### PR TITLE
Git ignore dist -directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 fetch-ssh-keys
+dist


### PR DESCRIPTION
Travis build creates 'dist' directory and build in Travis fails
because the created directory displays as "untracked directory"
to the git.