### PR TITLE
Use skip_cleanup in release deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ after_success:
   - ghr --username ernoaapa --token $GITHUB_TOKEN --replace --prerelease --debug pre-release dist/
 deploy:
   provider: script
+  skip_cleanup: true
   script: ghr --username ernoaapa --token $GITHUB_TOKEN --replace --debug $(git tag -l --contains HEAD) dist/
   on:
     tags: true


### PR DESCRIPTION
The latest release failed to deploy the artifacts to GitHub releases.

Looking in the [Travis CI log](https://travis-ci.org/ernoaapa/fetch-ssh-keys/jobs/286368457) we'll see (under _Preparing deploy_):
```
Cleaning up git repository with `git stash --all`. If you need build artifacts for deployment, set `deploy.skip_cleanup: true`. See https://docs.travis-ci.com/user/deployment/#Uploading-Files.
```
and (under _Deploying application_): 
```
Failed to find assets from dist/: failed to get file stat: stat /home/travis/gopath/src/github.com/ernoaapa/fetch-ssh-keys/dist: no such file or directory
```
I'm not sure if that is a new configuration or otherwise how releases ever succeeded previously.