### PR TITLE
Added --user flag to support fetching users public keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,11 @@ fetch-ssh-keys <source name> <parameters> <output file>
 
 For example fetch users public SSH keys from GitHub `my-lovely-team` team in `my-awesome-company` organization and output in SSH authorized_keys format
 ```shell
+# Fetch 'my-lovely-team' keys in 'my-awesome-company' organisation
 fetch-ssh-keys github --organization my-awesome-company --team my-lovely-team --token YOUR-TOKEN-HERE ./the-keys
+
+# Fetch 'ernoaapa' and 'arnested' public keys
+fetch-ssh-keys github --user ernoaapa --user arnested  --token YOUR-TOKEN-HERE ./the-keys
 ```
 
 Tool can be used for example to automatically update `.ssh/authorized_keys` file by giving path to `.ssh/authorized_keys` as last argument and adding the script to cron job.
@@ -30,12 +34,15 @@ Tool can be used for example to automatically update `.ssh/authorized_keys` file
 | --file-mode    | No (default 0600) | File permissions when writing to a file                                                                   |
 
 #### GitHub
-| Parameter      | Required | Description                                                                                               |
-|----------------|----------|-----------------------------------------------------------------------------------------------------------|
-| --organization | Yes      | Name of the organization which members keys to pick                                                       |
-| --team         | No       | Name of the team which members keys to pick                                                               |
-| --token        | No       | GitHub API token to use for communication. Without token you get only public members of the organization. |
-| --public-only  | No       | Return only members what are publicly members of the given organization                                   |
+| Parameter      | Description                                                                                               |
+|----------------|-----------------------------------------------------------------------------------------------------------|
+| --organization | Name of the organization which members keys to pick                                                       |
+| --team         | Name of the team which members keys to pick                                                               |
+| --user         | Name of the user which keys to pick                                                                       |
+| --token        | GitHub API token to use for communication. Without token you get only public members of the organization. |
+| --public-only  | Return only members what are publicly members of the given organization                                   |
+
+You can give `--organisation` (optionally combined with `--team` flag) and/or one or more `--user` flags.
 
 ## Development
 ### Get dependencies

--- a/fetch/github_test.go
+++ b/fetch/github_test.go
@@ -9,10 +9,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestFetchPublicKeys(t *testing.T) {
+func TestFetchOrganisationKeys(t *testing.T) {
 	log.SetLevel(log.DebugLevel)
 
-	keys, err := GitHubKeys("devopsfinland", GithubFetchParams{
+	keys, err := GitHubOrganisationKeys("devopsfinland", GithubFetchParams{
 		// Use token if it's available to avoid hitting API rate limits with the tests...
 		Token:             os.Getenv("GITHUB_TOKEN"),
 		PublicMembersOnly: true,
@@ -20,6 +20,17 @@ func TestFetchPublicKeys(t *testing.T) {
 
 	assert.NoError(t, err, "Fetch GitHub keys returned error")
 	assert.True(t, len(keys) > 0, "should return SSH at least one public key")
+	assert.True(t, len(keys["ernoaapa"]) > 0, "should return ernoaapa public SSH key")
+	assert.True(t, len(keys["ernoaapa"][0]) > 0, "should not return empty key for ernoaapa")
+}
+
+func TestFetchUserKeys(t *testing.T) {
+	log.SetLevel(log.DebugLevel)
+
+	keys, err := GitHubUsers([]string{"ernoaapa", "arnested"}, os.Getenv("GITHUB_TOKEN"))
+
+	assert.NoError(t, err, "Fetch GitHub keys returned error")
+	assert.Equal(t, 2, len(keys), "should return SSH keys for both users")
 	assert.True(t, len(keys["ernoaapa"]) > 0, "should return ernoaapa public SSH key")
 	assert.True(t, len(keys["ernoaapa"][0]) > 0, "should not return empty key for ernoaapa")
 }

--- a/utils/merge.go
+++ b/utils/merge.go
@@ -1,0 +1,18 @@
+package utils
+
+// MergeKeys merges key maps together to single map
+func MergeKeys(keySets ...map[string][]string) map[string][]string {
+	result := make(map[string][]string)
+
+	for _, userKeys := range keySets {
+		for username, keys := range userKeys {
+			if _, ok := result[username]; !ok {
+				result[username] = []string{}
+			}
+
+			result[username] = append(result[username], keys...)
+		}
+	}
+
+	return result
+}

--- a/utils/merge_test.go
+++ b/utils/merge_test.go
@@ -1,0 +1,23 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMergeKeys(t *testing.T) {
+	result := MergeKeys(map[string][]string{
+		"user-1": []string{"key1"},
+		"user-2": []string{"key1"},
+	}, map[string][]string{
+		"user-2": []string{"key2"},
+		"user-3": []string{"key1"},
+	})
+
+	assert.Equal(t, map[string][]string{
+		"user-1": []string{"key1"},
+		"user-2": []string{"key1", "key2"},
+		"user-3": []string{"key1"},
+	}, result)
+}


### PR DESCRIPTION
Sometimes you don't have organisation but you just want to fetch few users public keys. Now there's `--user` flag what does that; fetches users public keys.