### PR TITLE
Added support for using team name or url slug

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Tool can be used for example to automatically update `.ssh/authorized_keys` file
 | Parameter      | Description                                                                                               |
 |----------------|-----------------------------------------------------------------------------------------------------------|
 | --organization | Name of the organization which members keys to pick                                                       |
-| --team         | Name of the team which members keys to pick                                                               |
+| --team         | Name or slug of the team which members keys to pick                                                               |
 | --user         | Name of the user which keys to pick                                                                       |
 | --token        | GitHub API token to use for communication. Without token you get only public members of the organization. |
 | --public-only  | Return only members what are publicly members of the given organization                                   |

--- a/fetch/github.go
+++ b/fetch/github.go
@@ -87,7 +87,7 @@ func resolveTeamID(client *github.Client, organizationName, teamName string) (in
 	}
 
 	for _, team := range teams {
-		if strings.EqualFold(*team.Name, teamName) {
+		if strings.EqualFold(*team.Name, teamName) || strings.EqualFold(*team.Slug, teamName) {
 			return *team.ID, nil
 		}
 	}


### PR DESCRIPTION
It was really unclear that you must use team name "My team" not
team slug "my-team". Now you can use either name or slug in
`--team` parameter.