### PR TITLE
Add `--deploy-key` parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ fetch-ssh-keys github --organization my-awesome-company --team my-lovely-team --
 
 # Fetch 'ernoaapa' and 'arnested' public keys
 fetch-ssh-keys github --user ernoaapa --user arnested  --token YOUR-TOKEN-HERE ./the-keys
+
+# Fetch 'ernoaapa/fetch-ssh-keys' deploy keys (requires a Github token with the `repo` or `public_repo` scope)
+fetch-ssh-keys github --deploy-key ernoaapa/fetch-ssh-keys  --token YOUR-TOKEN-HERE ./the-keys
 ```
 
 Tool can be used for example to automatically update `.ssh/authorized_keys` file by giving path to `.ssh/authorized_keys` as last argument and adding the script to cron job.
@@ -40,10 +43,13 @@ Tool can be used for example to automatically update `.ssh/authorized_keys` file
 | --organization | Name of the organization which members keys to pick                                                       |
 | --team         | Name or slug of the team which members keys to pick                                                               |
 | --user         | Name of the user which keys to pick                                                                       |
+| --deploy-key   | Name of the owner/repo which deploy keys to pick                                                          |
 | --token        | GitHub API token to use for communication. Without token you get only public members of the organization. |
 | --public-only  | Return only members what are publicly members of the given organization                                   |
 
-You can give `--organisation` (optionally combined with `--team` flag) and/or one or more `--user` flags.
+You can give `--organisation` (optionally combined with `--team` flag) and/or one or more `--user` or `--deploy-key` flags.
+
+The `--deploy-key` parameter requires a Github token with the `repo` or `public_repo` scope.
 
 ## Development
 ### Get dependencies

--- a/fetch/github.go
+++ b/fetch/github.go
@@ -40,6 +40,12 @@ func GitHubUsers(usernames []string, token string) (map[string][]string, error) 
 	return fetchUserKeys(client, usernames, token)
 }
 
+// GitHubDeployKeys fetches repositories' SSH keys from GitHub
+func GitHubDeployKeys(ownerRepos []string, token string) (map[string][]string, error) {
+	client := getClient(token)
+	return fetchDeployKeys(client, ownerRepos, token)
+}
+
 func getClient(token string) *github.Client {
 	if len(token) > 0 {
 		ts := oauth2.StaticTokenSource(
@@ -109,6 +115,29 @@ func fetchUserKeys(client *github.Client, usernames []string, token string) (map
 
 		for index, key := range keys {
 			result[username][index] = *key.Key
+		}
+	}
+
+	return result, nil
+}
+
+func fetchDeployKeys(client *github.Client, ownerRepos []string, token string) (map[string][]string, error) {
+	ctx := context.Background()
+
+	result := map[string][]string{}
+	for _, ownerRepo := range ownerRepos {
+		ownerRepoSplit := strings.SplitN(ownerRepo, "/", 2)
+		owner := ownerRepoSplit[0]
+		repo := ownerRepoSplit[1]
+		keys, _, err := client.Repositories.ListKeys(ctx, owner, repo, &github.ListOptions{})
+		if err != nil {
+			return map[string][]string{}, err
+		}
+
+		result[ownerRepo] = make([]string, len(keys))
+
+		for index, key := range keys {
+			result[ownerRepo][index] = *key.Key
 		}
 	}
 

--- a/fetch/github.go
+++ b/fetch/github.go
@@ -61,7 +61,7 @@ func fetchUsers(client *github.Client, organizationName string, params GithubFet
 				return []*github.User{}, err
 			}
 
-			teamUsers, _, err := client.Organizations.ListTeamMembers(ctx, teamID, &github.OrganizationListTeamMembersOptions{})
+			teamUsers, _, err := client.Teams.ListTeamMembers(ctx, teamID, &github.TeamListTeamMembersOptions{})
 			if err != nil {
 				return []*github.User{}, err
 			}
@@ -81,7 +81,7 @@ func fetchUsers(client *github.Client, organizationName string, params GithubFet
 func resolveTeamID(client *github.Client, organizationName, teamName string) (int64, error) {
 	ctx := context.Background()
 
-	teams, _, err := client.Organizations.ListTeams(ctx, organizationName, &github.ListOptions{})
+	teams, _, err := client.Teams.ListTeams(ctx, organizationName, &github.ListOptions{})
 	if err != nil {
 		return -1, err
 	}

--- a/fetch/github_deploy_key_test.go
+++ b/fetch/github_deploy_key_test.go
@@ -1,0 +1,23 @@
+// +build deploy_key
+
+package fetch
+
+import (
+	"os"
+	"testing"
+
+	log "github.com/Sirupsen/logrus"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFetchDeployKeys(t *testing.T) {
+	log.SetLevel(log.DebugLevel)
+
+	keys, err := GitHubDeployKeys([]string{"arnested/fetch-ssh-keys"}, os.Getenv("GITHUB_TOKEN"))
+
+	assert.NoError(t, err, "Fetch GitHub keys returned error")
+	assert.Equal(t, 1, len(keys), "should return SSH keys for 'arnested/fetch-ssh-keys'")
+	assert.True(t, len(keys["arnested/fetch-ssh-keys"]) > 0, "should return 'arnested/fetch-ssh-keys' deploy SSH key")
+	assert.True(t, len(keys["arnested/fetch-ssh-keys"][0]) > 0, "should not return empty key for 'arnested/fetch-ssh-keys'")
+}


### PR DESCRIPTION
This adds a `--deploy-key` parameter for syncing the deploy keys of a Github repositories.

You can use it in combination with the `--user` and/or `--organization` parameters.

To be able to access deploy keys through Githubs API requires an access token with the `public_repo` or `repo` (for private repository) scope.

The test case is in its own file because of the dependency on a token. Use the build tag to test: `go test -tags=deploy_key ./...`