### PR TITLE
upstream: Sirupsen -> sirupsen name change

### DIFF
--- a/fetch/github.go
+++ b/fetch/github.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/google/go-github/github"
 	"golang.org/x/oauth2"
 )

--- a/fetch/github_deploy_key_test.go
+++ b/fetch/github_deploy_key_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"testing"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/fetch/github_test.go
+++ b/fetch/github_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/format/builder.go
+++ b/format/builder.go
@@ -1,6 +1,6 @@
 package format
 
-import log "github.com/Sirupsen/logrus"
+import log "github.com/sirupsen/logrus"
 
 // Build builds output in given formatName format
 func Build(formatName string, keysByUsername map[string][]string, comment string) string {

--- a/format/ssh_test.go
+++ b/format/ssh_test.go
@@ -3,7 +3,7 @@ package format
 import (
 	"testing"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/pkg/errors"
 
 	"github.com/ernoaapa/fetch-ssh-keys/fetch"

--- a/output/file_test.go
+++ b/output/file_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/output/stdout_test.go
+++ b/output/stdout_test.go
@@ -3,7 +3,7 @@ package output
 import (
 	"testing"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 func TestStdout(t *testing.T) {


### PR DESCRIPTION
In 2018 the GitHub "organization" github.com/Sirupsen changed to all
lower case.  While this was fine in a pre "Go Modules" world, this cases
breaking changes when using modules within Go.

A number of other Go projects have experienced this, for more detail
reference the following:

https://github.com/golang/go/issues/28489
https://github.com/golang/go/issues/26208